### PR TITLE
Change base image to ocrmypdf-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR $GOPATH/src/ocrmypdf-watchdog/
 ENV GO111MODULE=off
 RUN go get -d -v
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o /go/bin/main .
-FROM jbarlow83/ocrmypdf-alpine:v15.3.0
+FROM jbarlow83/ocrmypdf-alpine:v16.2.0
 COPY --from=builder /go/bin/main /app/
 WORKDIR /app
 VOLUME /in /bak /out

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR $GOPATH/src/ocrmypdf-watchdog/
 ENV GO111MODULE=off
 RUN go get -d -v
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o /go/bin/main .
-FROM jbarlow83/ocrmypdf:v15.3.0
+FROM jbarlow83/ocrmypdf-alpine:v15.3.0
 COPY --from=builder /go/bin/main /app/
 WORKDIR /app
 VOLUME /in /bak /out


### PR DESCRIPTION
The Ubuntu-based image is deprecated and will be removed in the future.

See https://ocrmypdf.readthedocs.io/en/latest/release_notes.html#v15-2-0 and especially https://ocrmypdf.readthedocs.io/en/latest/docker.html#installing-the-docker-image